### PR TITLE
Add 'option-renderer' property to select2 component

### DIFF
--- a/src/components/select2/AuiSelect2Single.vue
+++ b/src/components/select2/AuiSelect2Single.vue
@@ -15,7 +15,8 @@
       placeholder: String,
       query: Function,
       value: String,
-      width: String
+      width: String,
+      optionRenderer: Function
     },
 
     data: function () {
@@ -42,7 +43,9 @@
         data: () => ({results: this.options}),
         placeholder: this.placeholder,
         width: this.width,
-        dropdownAutoWidth: this.dropdownAutoWidth
+        dropdownAutoWidth: this.dropdownAutoWidth,
+        formatResult: (state) => state.text,
+        formatSelection: (state) => state.text
       });
       this.$input.on('change', this.onSelect2ValueChanged)
     },
@@ -64,8 +67,11 @@
       updateOptions() {
         this.options = this.$children.map(child => {
           const id = child.value
-          const text = child.$slots.default[0].text
-          return {id, text}
+          let text = child.$slots.default[0].text
+          if (this.optionRenderer) {
+            text = this.optionRenderer( text )
+          }
+          return { id, text }
         })
         if (this.$input) {
           this.$input.auiSelect2('val', this.value);


### PR DESCRIPTION
Add a new property to select2 component to give access to the rendering functions of the wrapped select2 component to customize rendering of options.

For example, if you want to create a color picker:

In the view:
`<aui-select2-single  :option-renderer="colorOptionRenderer" v-model="xxxx.color.name">
       #foreach($color in $colors )
            <aui-select2-option value="$color.name()">$color.background</aui-select2-option>
       #end
</aui-select2-single>`

"ColorOptionRenderer" method in js:

`dialogVue = new Vue({
	    el : '#your-element',
	    data : {
		...
		colorOptionRenderer : (colorCode) => '<div class="holydev-calendar-color-option" style="background:' + colorCode + '"></div>'
	    },
                ...
`