### PR TITLE
Remove options.find() method as it is not supported by IE

### DIFF
--- a/src/components/select2/auiSelect2Mixin.js
+++ b/src/components/select2/auiSelect2Mixin.js
@@ -75,7 +75,17 @@ export default {
     },
 
     mapToOriginalVal(stringValue) {
-      const original = this.options.find(option => `${option.value}` === stringValue);
+
+      function getOption(options, stringValue){
+        for (let i = 0; i < options.length; i++) {
+          let option = options[i]
+          if (`${option.value}` === stringValue){
+            return option
+          }
+        }
+      }
+
+      const original = getOption(this.options, stringValue);
       return original && original.value || stringValue;
     },
 


### PR DESCRIPTION
The last commit of src/components/select2/auiSelect2Mixin.js included a find() method on the options array.
This is not supported at least by IE 11 that I need to be working without usage of polyfill.
I have replaced the find() method by a function compatible with browsers not supporting the find() function.