### PR TITLE
🅰️  Default lozenge can be passed as type prop

### DIFF
--- a/src/components/AuiLozenge.vue
+++ b/src/components/AuiLozenge.vue
@@ -9,7 +9,7 @@
       type: {
         type: String,
         validator(value) {
-          const types = ['success', 'error', 'current', 'complete', 'moved']
+          const types = ['default', 'success', 'error', 'current', 'complete', 'moved']
           return types.indexOf(value) >= 0
         }
       }

--- a/src/docs/component/Lozenges.vue
+++ b/src/docs/component/Lozenges.vue
@@ -29,7 +29,7 @@
 
     <div class="aui-item">
       <api-table name="aui-lozenge" :props="[
-      {name: 'type', type: 'String', default: 'medium', description: 'Available: \'success\', \'error\', \'current\', \'complete\', \'moved\''},
+      {name: 'type', type: 'String', default: 'default', description: 'Available: \'success\', \'error\', \'current\', \'complete\', \'moved\''},
       {name: 'subtle', type: 'Boolean', default: 'false', description: 'Renders subtle lozenge without background.'},
     ]">
       </api-table>


### PR DESCRIPTION
If we use `<aui-lozenge type="default">` it generates a warn. I cannot create a switch to conditionally set the lozenge type.